### PR TITLE
refs #12 エラー表示でコマンド部分のみをエラーとして表示する

### DIFF
--- a/src/components/Command.tsx
+++ b/src/components/Command.tsx
@@ -63,7 +63,10 @@ const handler = (
     // pathの抽出と/の削除
     let path = command.replace('cd ', '').replace(/\/$/, '');
 
-    if (currentDir === GENSHI_PATH && path === 'products') {
+    if (path === '.' || path === './'){
+      return '';
+    }
+    else if (currentDir === GENSHI_PATH && path === 'products') {
       dirItem = LS_PRODUCTS_ITEM;
       setCurrentDir(GENSHI_PATH + '/' + path);
     } else if (currentDir === GENSHI_PATH && path === 'contacts') {

--- a/src/components/command/NotFound.tsx
+++ b/src/components/command/NotFound.tsx
@@ -6,7 +6,10 @@ type Props = {
 };
 
 const NotFound: FC<Props> = ({ command }) => (
-  <UbuntuText>bash: command not found: {command}</UbuntuText>
+  // コマンド全文からコマンド部分だけを取り出す
+  <UbuntuText>
+    bash: command not found: {command.substring(0, command.indexOf(' ') + 1)}
+  </UbuntuText>
 );
 
 export default NotFound;


### PR DESCRIPTION
- zshとbashでエラーの表示のされ方が違うことに気づいたので #12 に添付した画像のcd hoge のほうは問題なかった.
- エラーが全文表示されるバグの解決.
- cd . やcd ./でエラーが表示されるバグの解決.